### PR TITLE
feat: TitleSection 스타일 정의 (#15)

### DIFF
--- a/src/styles/common/TitleSection.ts
+++ b/src/styles/common/TitleSection.ts
@@ -1,0 +1,29 @@
+import styled from "styled-components";
+
+interface WrapperProps {
+  gap?: string;
+}
+export const Wrapper = styled.div<WrapperProps>`
+  width: 100vw;
+  display: flex;
+  justify-content: flex-start;
+  gap: ${({ gap }) => gap || "30px"};
+  padding-left: 14.68vw;
+`;
+export const TitleWrapper = styled.div`
+  margin-bottom: 10px;
+`;
+export const Title = styled.h2`
+  font-size: 2.4vw;
+  font-size: clamp(24px, 2.4vw, 36px);
+  margin-bottom: 20px;
+  font-weight: 600;
+  color: white;
+`;
+export const H4 = styled.h4`
+  font-size: 1.3vw;
+  font-size: clamp(13.5px, 1.3vw, 24px);
+  margin-bottom: 20px;
+  color: #a2a2a2;
+  font-weight: 400;
+`;


### PR DESCRIPTION
<!--
feat: TitleSection 스타일 정의(#15 )
-->

##  📌 관련 이슈

- closed: #15

## ✨ PR 세부 내용
src/styles/common 폴더를 생성하고 TitleSection.ts 파일을 작성했어요

**TitleSection 스타일 사용 방법**

TitleSection.ts 파일을 import합니다
![code1](https://github.com/user-attachments/assets/25b49eb1-2293-4fa4-8593-b919dec2cde2)

불러온 파일의 컴포넌트는 <S.{컴포넌트명}> </S.{컴포넌트명}> 과 같은 방식으로 사용할 수 있습니다
![code](https://github.com/user-attachments/assets/457ce696-1a05-4e85-a2ef-0ece75b4c895)


✳️ 캘린더나 More 버튼이 있는 경우 Wrapper 에 gap을 props로 전달하여 위치 조정 가능합니다

## ⌛ 소요 시간
