### PR TITLE
feat: 로그인시 경기 스크랩 기능 구현 (#30)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
   },
   "dependencies": {
     "@types/react-slick": "^0.23.13",
-    "axios": "^1.7.2",
+    "axios": "^1.7.4",
     "date-fns": "^3.6.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.24.1",
     "react-slick": "^0.30.2",
+    "react-toastify": "^10.0.5",
     "slick-carousel": "^1.8.1",
     "styled-components": "^6.1.11",
     "zustand": "^4.5.4"
@@ -30,7 +31,7 @@
     "@types/react-slick": "^0.23.13",
     "@types/styled-components": "^5.1.34",
     "@typescript-eslint/parser": "^7.13.1",
-    "@vitejs/plugin-react-swc": "^3.5.0",
+    "@vitejs/plugin-react-swc": "^3.7.0",
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.7",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,21 @@
 import "./App.css";
 import Router from "./Router";
 import Layout from "./components/layout/Layout";
+import "react-toastify/dist/ReactToastify.css";
+import { ToastContainer } from "react-toastify";
 
 function App() {
   return (
-  <Layout>
-    <Router isAuthenticated={true}/>
-  </Layout>
-  )
+    <Layout>
+      <ToastContainer
+        theme="dark"
+        autoClose={1000}
+        hideProgressBar
+        newestOnTop
+      />
+      <Router isAuthenticated={true} />
+    </Layout>
+  );
 }
 
 export default App;

--- a/src/components/home/Card.tsx
+++ b/src/components/home/Card.tsx
@@ -10,6 +10,7 @@ import Category from "./Category";
 // import useStore from "../../store/useStore";
 import * as S from "../../styles/common/TitleSection";
 import axios from "axios";
+import { toast } from "react-toastify";
 
 export const teamLogos: Record<string, string> = {
   LG: "https://yaguhang.kro.kr:8443/teamLogos/LGTwins.png",
@@ -65,22 +66,22 @@ const StyledCard = styled.div<StyledCardProps>`
   padding: 1rem;
   margin: 0.8rem;
   border: 1px solid #ffffff;
-  &::before {
-    content: "";
-    position: absolute;
-    top: -2.2rem;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 4rem;
-    height: 4rem;
-    background-color: #fff;
-    border-radius: 50%;
-    box-shadow: 0 0.5rem 0.5rem rgba(0, 0, 0, 0.7);
-    background-image: url(${(props) =>
-      props.$isScraped ? checkedball : ball});
-    background-size: cover;
-    z-index: 99;
-  }
+`;
+
+const BeforeElement = styled.div<StyledCardProps>`
+  position: absolute;
+  top: -2.2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 4rem;
+  height: 4rem;
+  background-color: #fff;
+  border-radius: 50%;
+  box-shadow: 0 0.5rem 0.5rem rgba(0, 0, 0, 0.7);
+  background-image: url(${(props) => (props.$isScraped ? checkedball : ball)});
+  background-size: cover;
+  z-index: 99;
+  cursor: pointer;
 `;
 
 const Divider = styled.div`
@@ -137,11 +138,17 @@ const Card: React.FC = () => {
   const [currentPage, setCurrentPage] = useState(0);
 
   const fetchSchedules = async (team: string) => {
+    const token = localStorage.getItem("token") || "";
     try {
       const response = await axios.get<{ schedules: Schedule[] }>(
         `https://yaguhang.kro.kr:8443/api/main/schedule/?team=${encodeURIComponent(
           team
-        )}&page=0&size=50`
+        )}&page=0&size=50`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
       );
       setSchedules(response.data.schedules);
       setCurrentPage(0); // 페이지를 초기화합니다.
@@ -174,6 +181,38 @@ const Card: React.FC = () => {
     }
   };
 
+  const scrapSchedule = async (gameId: number) => {
+    try {
+      const token = localStorage.getItem("token") || "";
+      const response = await axios.patch<{}>(
+        `https://yaguhang.kro.kr:8443/api/scraps/schedule/scrap?gameId=${gameId}`,
+        {},
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      const isScraped = response.data === "add scrap";
+
+      setSchedules((prevSchedules) =>
+        prevSchedules.map((schedule) =>
+          schedule.id === gameId
+            ? { ...schedule, isScraped: !schedule.isScraped }
+            : schedule
+        )
+      );
+
+      toast.success(
+        isScraped ? "스크랩에 추가되었습니다." : "스크랩에서 제거되었습니다."
+      );
+    } catch (error) {
+      toast.error("스크랩 중 오류가 발생했습니다.");
+      console.error("Error scrapping schedule:", error);
+    }
+  };
+
   return (
     <>
       <Category filterSchedules={fetchSchedules} teamLogos={teamLogos} />{" "}
@@ -191,6 +230,10 @@ const Card: React.FC = () => {
         </PrevButton>
         {currentSchedules.map((schedule) => (
           <StyledCard key={schedule.id} $isScraped={schedule.isScraped}>
+            <BeforeElement
+              $isScraped={schedule.isScraped}
+              onClick={() => scrapSchedule(schedule.id)}
+            />
             <div style={{ marginTop: "2rem" }}>
               <div>
                 {schedule.stadium} | {schedule.time}

--- a/src/components/home/Category.tsx
+++ b/src/components/home/Category.tsx
@@ -1,19 +1,6 @@
 import { useState } from "react";
 import styled from "styled-components";
 
-// const teamLogos: Record<string, string> = {
-//   LG: "https://yaguhang.kro.kr:8443/teamLogos/LGTwins.png",
-//   KT: "https://yaguhang.kro.kr:8443/teamLogos/KtWizs.png",
-//   SSG: "https://yaguhang.kro.kr:8443/teamLogos/SSGLanders.png",
-//   NC: "https://yaguhang.kro.kr:8443/teamLogos/NCDinos.png",
-//   두산: "https://yaguhang.kro.kr:8443/teamLogos/Doosan.png",
-//   KIA: "https://yaguhang.kro.kr:8443/teamLogos/KIA.png",
-//   롯데: "https://yaguhang.kro.kr:8443/teamLogos/Lotte.png",
-//   삼성: "https://yaguhang.kro.kr:8443/teamLogos/Samsung.png",
-//   한화: "https://yaguhang.kro.kr:8443/teamLogos/Hanwha.png",
-//   키움: "https://yaguhang.kro.kr:8443/teamLogos/Kiwoom.png",
-// };
-
 const ButtonContainer = styled.div`
   display: flex;
   justify-content: center;

--- a/yarn.lock
+++ b/yarn.lock
@@ -513,9 +513,9 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@vitejs/plugin-react-swc@^3.5.0":
+"@vitejs/plugin-react-swc@^3.7.0":
   version "3.7.0"
-  resolved "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.7.0.tgz"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react-swc/-/plugin-react-swc-3.7.0.tgz#e456c0a6d7f562268e1d231af9ac46b86ef47d88"
   integrity sha512-yrknSb3Dci6svCd/qhHqhFPDSw0QtjumcqdKMoNNzmOl5lMXTTiqzjWtG4Qask2HdvvzaNgSunbQGet8/GrKdA==
   dependencies:
     "@swc/core" "^1.5.7"
@@ -567,10 +567,10 @@ asynckit@^0.4.0:
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz"
-  integrity sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==
+axios@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.4.tgz#4c8ded1b43683c8dd362973c393f3ede24052aa2"
+  integrity sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"
@@ -625,6 +625,11 @@ classnames@^2.2.5:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
   integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
+
+clsx@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -1340,6 +1345,13 @@ react-slick@^0.30.2:
     json2mq "^0.2.0"
     lodash.debounce "^4.0.8"
     resize-observer-polyfill "^1.5.0"
+
+react-toastify@^10.0.5:
+  version "10.0.5"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-10.0.5.tgz#6b8f8386060c5c856239f3036d1e76874ce3bd1e"
+  integrity sha512-mNKt2jBXJg4O7pSdbNUfDdTsK9FIdikfsIE/yUCxbAEXl4HMyJaivrVFcn3Elvt5xvCQYhUZm+hqTIu1UXM3Pw==
+  dependencies:
+    clsx "^2.1.0"
 
 react@^18.3.1:
   version "18.3.1"


### PR DESCRIPTION
##  📌 관련 이슈 
         라이브러리 하나 설치했으니 yarn install 해주세용
         특정 경기 일정을 스크랩(저장)할 수 있는 기능을 추가했습니다.
	•	스크랩된 일정은 로컬 스토리지에 임의로 토큰을 저장하여 테스트 했습니다.
	•	스크랩을 추가하거나 제거할 수 있습니다.

- closed: #30 

## ✨ PR 세부 내용

**toast 사용법! ex)
<img width="310" alt="스크린샷 2024-08-15 15 00 29" src="https://github.com/user-attachments/assets/e05afd52-7977-41c3-97ef-db33f17a5180">
<img width="465" alt="스크린샷 2024-08-15 14 59 40" src="https://github.com/user-attachments/assets/bf6a8eda-0490-4b21-9f2c-b31403b20fd7">

<!-- 수정/추가한 내용을 적어주세요. -->


https://github.com/user-attachments/assets/0b9a3561-c5d0-4cfb-aeff-c2267079812a

