### PR TITLE
feat: api호출 분리 및 zustand 팀 선택 상태관리 #27

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
   },
   "dependencies": {
     "@types/react-slick": "^0.23.13",
-    "axios": "^1.7.2",
+    "axios": "^1.7.4",
     "date-fns": "^3.6.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.24.1",
     "react-slick": "^0.30.2",
+    "react-toastify": "^10.0.5",
     "slick-carousel": "^1.8.1",
     "styled-components": "^6.1.11",
     "zustand": "^4.5.4"
@@ -30,7 +31,7 @@
     "@types/react-slick": "^0.23.13",
     "@types/styled-components": "^5.1.34",
     "@typescript-eslint/parser": "^7.13.1",
-    "@vitejs/plugin-react-swc": "^3.5.0",
+    "@vitejs/plugin-react-swc": "^3.7.0",
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.7",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,21 @@
 import "./App.css";
 import Router from "./Router";
 import Layout from "./components/layout/Layout";
+import "react-toastify/dist/ReactToastify.css";
+import { ToastContainer } from "react-toastify";
 
 function App() {
   return (
-  <Layout>
-    <Router isAuthenticated={true}/>
-  </Layout>
-  )
+    <Layout>
+      <ToastContainer
+        theme="dark"
+        autoClose={1000}
+        hideProgressBar
+        newestOnTop
+      />
+      <Router isAuthenticated={true} />
+    </Layout>
+  );
 }
 
 export default App;

--- a/src/apis/main/index.ts
+++ b/src/apis/main/index.ts
@@ -1,4 +1,6 @@
 import { defaultApi } from "../core/index";
+import { Schedule } from "../../components/home/Card";
+
 export const home = {
   place: async (stadium: string, category: string) => {
     try {
@@ -12,4 +14,42 @@ export const home = {
       throw error;
     }
   },
+};
+
+export const fetchSchedules = async (team: string): Promise<Schedule[]> => {
+  const token = localStorage.getItem("token") || "";
+  try {
+    const response = await defaultApi.get<{ schedules: Schedule[] }>(
+      `/api/main/schedule/?team=${encodeURIComponent(team)}&page=0&size=50`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    return response.data.schedules;
+  } catch (error) {
+    console.error("Error fetching schedules:", error);
+    throw error;
+  }
+};
+
+export const scrapSchedule = async (gameId: number) => {
+  const token = localStorage.getItem("token") || "";
+  try {
+    const response = await defaultApi.patch<{}>(
+      `/api/scraps/schedule/scrap?gameId=${gameId}`,
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    return response.data === "add scrap";
+  } catch (error) {
+    console.error("Error scrapping schedule:", error);
+    throw error;
+  }
 };

--- a/src/components/home/Card.tsx
+++ b/src/components/home/Card.tsx
@@ -10,6 +10,7 @@ import Category from "./Category";
 // import useStore from "../../store/useStore";
 import * as S from "../../styles/common/TitleSection";
 import axios from "axios";
+import { toast } from "react-toastify";
 
 export const teamLogos: Record<string, string> = {
   LG: "https://yaguhang.kro.kr:8443/teamLogos/LGTwins.png",
@@ -65,22 +66,22 @@ const StyledCard = styled.div<StyledCardProps>`
   padding: 1rem;
   margin: 0.8rem;
   border: 1px solid #ffffff;
-  &::before {
-    content: "";
-    position: absolute;
-    top: -2.2rem;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 4rem;
-    height: 4rem;
-    background-color: #fff;
-    border-radius: 50%;
-    box-shadow: 0 0.5rem 0.5rem rgba(0, 0, 0, 0.7);
-    background-image: url(${(props) =>
-      props.$isScraped ? checkedball : ball});
-    background-size: cover;
-    z-index: 99;
-  }
+`;
+
+const BeforeElement = styled.div<StyledCardProps>`
+  position: absolute;
+  top: -2.2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 4rem;
+  height: 4rem;
+  background-color: #fff;
+  border-radius: 50%;
+  box-shadow: 0 0.5rem 0.5rem rgba(0, 0, 0, 0.7);
+  background-image: url(${(props) => (props.$isScraped ? checkedball : ball)});
+  background-size: cover;
+  z-index: 99;
+  cursor: pointer;
 `;
 
 const Divider = styled.div`
@@ -137,11 +138,17 @@ const Card: React.FC = () => {
   const [currentPage, setCurrentPage] = useState(0);
 
   const fetchSchedules = async (team: string) => {
+    const token = localStorage.getItem("token") || "";
     try {
       const response = await axios.get<{ schedules: Schedule[] }>(
         `https://yaguhang.kro.kr:8443/api/main/schedule/?team=${encodeURIComponent(
           team
-        )}&page=0&size=50`
+        )}&page=0&size=50`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
       );
       setSchedules(response.data.schedules);
       setCurrentPage(0); // 페이지를 초기화합니다.
@@ -174,6 +181,38 @@ const Card: React.FC = () => {
     }
   };
 
+  const scrapSchedule = async (gameId: number) => {
+    try {
+      const token = localStorage.getItem("token") || "";
+      const response = await axios.patch<{}>(
+        `https://yaguhang.kro.kr:8443/api/scraps/schedule/scrap?gameId=${gameId}`,
+        {},
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      const isScraped = response.data === "add scrap";
+
+      setSchedules((prevSchedules) =>
+        prevSchedules.map((schedule) =>
+          schedule.id === gameId
+            ? { ...schedule, isScraped: !schedule.isScraped }
+            : schedule
+        )
+      );
+
+      toast.success(
+        isScraped ? "스크랩에 추가되었습니다." : "스크랩에서 제거되었습니다."
+      );
+    } catch (error) {
+      toast.error("스크랩 중 오류가 발생했습니다.");
+      console.error("Error scrapping schedule:", error);
+    }
+  };
+
   return (
     <>
       <Category filterSchedules={fetchSchedules} teamLogos={teamLogos} />{" "}
@@ -191,6 +230,10 @@ const Card: React.FC = () => {
         </PrevButton>
         {currentSchedules.map((schedule) => (
           <StyledCard key={schedule.id} $isScraped={schedule.isScraped}>
+            <BeforeElement
+              $isScraped={schedule.isScraped}
+              onClick={() => scrapSchedule(schedule.id)}
+            />
             <div style={{ marginTop: "2rem" }}>
               <div>
                 {schedule.stadium} | {schedule.time}

--- a/src/components/home/Card.tsx
+++ b/src/components/home/Card.tsx
@@ -5,11 +5,11 @@ import checkedball from "../../assets/icons/checkedball.svg";
 import left from "../../assets/icons/left.png";
 import right from "../../assets/icons/right.png";
 import Category from "./Category";
-// import useStore from "../../store/useStore";
 import * as S from "../../styles/common/TitleSection";
 import { toast } from "react-toastify";
 import { fetchSchedules } from "../../apis/main";
 import { scrapSchedule } from "../../apis/main";
+import useTeamStore from "../../store/TeamStore";
 
 export const teamLogos: Record<string, string> = {
   LG: "https://yaguhang.kro.kr:8443/teamLogos/LGTwins.png",
@@ -135,14 +135,16 @@ const NextButton = styled(PaginationButton)`
 const Card: React.FC = () => {
   const [schedules, setSchedules] = useState<Schedule[]>([]);
   const [currentPage, setCurrentPage] = useState(0);
+  const { selectedTeam } = useTeamStore();
 
   useEffect(() => {
     const loadSchedules = async () => {
-      const schedules = await fetchSchedules("전체");
+      const schedules = await fetchSchedules(selectedTeam);
       setSchedules(schedules);
+      setCurrentPage(0); // 팀이 변경될 때 페이지를 초기화
     };
     loadSchedules();
-  }, []);
+  }, [selectedTeam]); // selectedTeam이 변경될 때마다 경기일정 필터링
 
   const schedulesPerPage = 5;
   const indexOfLastSchedule = (currentPage + 1) * schedulesPerPage;

--- a/src/components/home/Card.tsx
+++ b/src/components/home/Card.tsx
@@ -4,13 +4,12 @@ import ball from "../../assets/icons/ball.svg";
 import checkedball from "../../assets/icons/checkedball.svg";
 import left from "../../assets/icons/left.png";
 import right from "../../assets/icons/right.png";
-// import { format } from "date-fns";
-// import { ko } from "date-fns/locale";
 import Category from "./Category";
 // import useStore from "../../store/useStore";
 import * as S from "../../styles/common/TitleSection";
-import axios from "axios";
 import { toast } from "react-toastify";
+import { fetchSchedules } from "../../apis/main";
+import { scrapSchedule } from "../../apis/main";
 
 export const teamLogos: Record<string, string> = {
   LG: "https://yaguhang.kro.kr:8443/teamLogos/LGTwins.png",
@@ -25,7 +24,7 @@ export const teamLogos: Record<string, string> = {
   키움: "https://yaguhang.kro.kr:8443/teamLogos/Kiwoom.png",
 };
 
-interface Schedule {
+export interface Schedule {
   id: number;
   home: string;
   away: string;
@@ -137,28 +136,12 @@ const Card: React.FC = () => {
   const [schedules, setSchedules] = useState<Schedule[]>([]);
   const [currentPage, setCurrentPage] = useState(0);
 
-  const fetchSchedules = async (team: string) => {
-    const token = localStorage.getItem("token") || "";
-    try {
-      const response = await axios.get<{ schedules: Schedule[] }>(
-        `https://yaguhang.kro.kr:8443/api/main/schedule/?team=${encodeURIComponent(
-          team
-        )}&page=0&size=50`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
-      setSchedules(response.data.schedules);
-      setCurrentPage(0); // 페이지를 초기화합니다.
-    } catch (error) {
-      console.error("Error fetching schedules:", error);
-    }
-  };
-
   useEffect(() => {
-    fetchSchedules("전체");
+    const loadSchedules = async () => {
+      const schedules = await fetchSchedules("전체");
+      setSchedules(schedules);
+    };
+    loadSchedules();
   }, []);
 
   const schedulesPerPage = 5;
@@ -181,21 +164,9 @@ const Card: React.FC = () => {
     }
   };
 
-  const scrapSchedule = async (gameId: number) => {
+  const handleScrapSchedule = async (gameId: number) => {
     try {
-      const token = localStorage.getItem("token") || "";
-      const response = await axios.patch<{}>(
-        `https://yaguhang.kro.kr:8443/api/scraps/schedule/scrap?gameId=${gameId}`,
-        {},
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
-
-      const isScraped = response.data === "add scrap";
-
+      const isScraped = await scrapSchedule(gameId);
       setSchedules((prevSchedules) =>
         prevSchedules.map((schedule) =>
           schedule.id === gameId
@@ -203,13 +174,11 @@ const Card: React.FC = () => {
             : schedule
         )
       );
-
       toast.success(
         isScraped ? "스크랩에 추가되었습니다." : "스크랩에서 제거되었습니다."
       );
     } catch (error) {
       toast.error("스크랩 중 오류가 발생했습니다.");
-      console.error("Error scrapping schedule:", error);
     }
   };
 
@@ -232,7 +201,7 @@ const Card: React.FC = () => {
           <StyledCard key={schedule.id} $isScraped={schedule.isScraped}>
             <BeforeElement
               $isScraped={schedule.isScraped}
-              onClick={() => scrapSchedule(schedule.id)}
+              onClick={() => handleScrapSchedule(schedule.id)}
             />
             <div style={{ marginTop: "2rem" }}>
               <div>

--- a/src/components/home/Category.tsx
+++ b/src/components/home/Category.tsx
@@ -1,19 +1,6 @@
 import { useState } from "react";
 import styled from "styled-components";
 
-// const teamLogos: Record<string, string> = {
-//   LG: "https://yaguhang.kro.kr:8443/teamLogos/LGTwins.png",
-//   KT: "https://yaguhang.kro.kr:8443/teamLogos/KtWizs.png",
-//   SSG: "https://yaguhang.kro.kr:8443/teamLogos/SSGLanders.png",
-//   NC: "https://yaguhang.kro.kr:8443/teamLogos/NCDinos.png",
-//   두산: "https://yaguhang.kro.kr:8443/teamLogos/Doosan.png",
-//   KIA: "https://yaguhang.kro.kr:8443/teamLogos/KIA.png",
-//   롯데: "https://yaguhang.kro.kr:8443/teamLogos/Lotte.png",
-//   삼성: "https://yaguhang.kro.kr:8443/teamLogos/Samsung.png",
-//   한화: "https://yaguhang.kro.kr:8443/teamLogos/Hanwha.png",
-//   키움: "https://yaguhang.kro.kr:8443/teamLogos/Kiwoom.png",
-// };
-
 const ButtonContainer = styled.div`
   display: flex;
   justify-content: center;

--- a/src/components/home/Category.tsx
+++ b/src/components/home/Category.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
 import styled from "styled-components";
+import { useTeamStore } from "../../store/TeamStore";
 
 const ButtonContainer = styled.div`
   display: flex;
@@ -84,7 +84,7 @@ interface CategoryProps {
 }
 
 const Category: React.FC<CategoryProps> = ({ filterSchedules, teamLogos }) => {
-  const [selectedTeam, setSelectedTeam] = useState<string>("전체");
+  const { selectedTeam, setSelectedTeam } = useTeamStore();
 
   const handleButtonClick = (team: string) => {
     setSelectedTeam(team);

--- a/src/store/TeamStore.ts
+++ b/src/store/TeamStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 
 // 상태와 상태를 변경하는 함수들의 타입을 정의합니다.
-interface ClubStore {
+interface TeamStore {
   selectedTeam: string;
   setSelectedTeam: (team: string) => void;
   schedules: Schedule[];
@@ -24,11 +24,11 @@ interface Schedule {
 }
 
 //상태 관리 스토어를 생성.
-const useStore = create<ClubStore>((set) => ({
-  selectedTeam: "전체", // 현재 선택된 팀을 저장하는 상태.
+export const useTeamStore = create<TeamStore>((set) => ({
+  selectedTeam: "전체", // 현재 선택된 팀을 저장하는 상태. 초기값=전체
   setSelectedTeam: (team: string) => set({ selectedTeam: team }), // 선택된 팀을 변경하는 함수.
   schedules: [], // 현재 표시할 스케줄 목록을 저장하는 상태.
   setSchedules: (schedules: Schedule[]) => set({ schedules }), // 스케줄 목록을 변경하는 함수.
 }));
 
-export default useStore;
+export default useTeamStore;

--- a/yarn.lock
+++ b/yarn.lock
@@ -513,9 +513,9 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@vitejs/plugin-react-swc@^3.5.0":
+"@vitejs/plugin-react-swc@^3.7.0":
   version "3.7.0"
-  resolved "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.7.0.tgz"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react-swc/-/plugin-react-swc-3.7.0.tgz#e456c0a6d7f562268e1d231af9ac46b86ef47d88"
   integrity sha512-yrknSb3Dci6svCd/qhHqhFPDSw0QtjumcqdKMoNNzmOl5lMXTTiqzjWtG4Qask2HdvvzaNgSunbQGet8/GrKdA==
   dependencies:
     "@swc/core" "^1.5.7"
@@ -567,10 +567,10 @@ asynckit@^0.4.0:
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz"
-  integrity sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==
+axios@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.4.tgz#4c8ded1b43683c8dd362973c393f3ede24052aa2"
+  integrity sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"
@@ -625,6 +625,11 @@ classnames@^2.2.5:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
   integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
+
+clsx@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -1340,6 +1345,13 @@ react-slick@^0.30.2:
     json2mq "^0.2.0"
     lodash.debounce "^4.0.8"
     resize-observer-polyfill "^1.5.0"
+
+react-toastify@^10.0.5:
+  version "10.0.5"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-10.0.5.tgz#6b8f8386060c5c856239f3036d1e76874ce3bd1e"
+  integrity sha512-mNKt2jBXJg4O7pSdbNUfDdTsK9FIdikfsIE/yUCxbAEXl4HMyJaivrVFcn3Elvt5xvCQYhUZm+hqTIu1UXM3Pw==
+  dependencies:
+    clsx "^2.1.0"
 
 react@^18.3.1:
   version "18.3.1"


### PR DESCRIPTION
##  📌 관련 이슈

- closed: #27 

## ✨ PR 세부 내용

Zustand 적용:
	•	useTeamStore파일을 만들어서 전역에서 팀 선택 상태를 관리하도록 했습니다.
	•	selectedTeam 상태가 변경될 때마다 해당 팀의 경기 일정이 불러와집니다.
	2.	경기 일정 필터링:
	•	useEffect를 사용하여 selectedTeam이 변경될 때마다 fetchSchedules 함수를 호출해 데이터를 가져옵니다.
	•	일정 데이터 로딩 시 페이지네이션 상태를 초기화하여 사용자가 처음부터 일정을 확인할 수 있도록 했습니다.
