### PR TITLE
feat: 구단 선택 말풍선 추가(#92)

### DIFF
--- a/src/components/common/Balloon.tsx
+++ b/src/components/common/Balloon.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import styled, { keyframes } from "styled-components";
+
+interface BalloonProps {
+  content: string;
+  position?: { top: any; left: any };
+}
+
+const Balloon: React.FC<BalloonProps> = ({ content, position }) => {
+  return (
+    <BalloonContainer
+      style={{ top: position?.top ?? 0, left: position?.left ?? 0 }}
+    >
+      {content}
+      <BalloonArrow />
+    </BalloonContainer>
+  );
+};
+
+export default Balloon;
+
+const float = keyframes`
+  0% {
+    transform: translate(-50%, -50%) translateY(0);
+  }
+  50% {
+    transform: translate(-50%, -50%) translateY(-5px);
+  }
+  100% {
+    transform: translate(-50%, -50%) translateY(0);
+  }
+`;
+
+const BalloonContainer = styled.div`
+  position: absolute;
+  background-color: #fff;
+  padding: 8px;
+  border-radius: 10px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  z-index: 100;
+  transform: translate(-50%, -50%);
+  white-space: nowrap;
+  width: fit-content;
+  font-size: 0.8rem;
+  animation: ${float} 1.5s ease-in-out infinite; // 동동 뜨는 애니메이션
+`;
+
+const BalloonArrow = styled.div`
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-top: 8px solid #fff;
+  bottom: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+`;

--- a/src/components/common/Balloon.tsx
+++ b/src/components/common/Balloon.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled, { keyframes } from "styled-components";
 
 interface BalloonProps {
@@ -41,8 +40,11 @@ const BalloonContainer = styled.div`
   transform: translate(-50%, -50%);
   white-space: nowrap;
   width: fit-content;
-  font-size: 0.8rem;
   animation: ${float} 1.5s ease-in-out infinite; // 동동 뜨는 애니메이션
+
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: #303030;
 `;
 
 const BalloonArrow = styled.div`

--- a/src/components/common/ProfileComponent.tsx
+++ b/src/components/common/ProfileComponent.tsx
@@ -23,7 +23,7 @@ const ProfileComponent = ({
 }: ProfileComponentProps) => {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const teamLogoRef = useRef<HTMLDivElement | null>(null);
-  const [balloonPosition, setBalloonPosition] = useState<{
+  const [, setBalloonPosition] = useState<{
     top: number;
     left: number;
   } | null>(null);
@@ -38,7 +38,8 @@ const ProfileComponent = ({
   useEffect(() => {
     if (teamLogoRef.current && showBalloon) {
       const rect = teamLogoRef.current.getBoundingClientRect();
-      setBalloonPosition({ //중앙 위쪽
+      setBalloonPosition({
+        //중앙 위쪽
         top: rect.top - 30,
         left: rect.left + rect.width / 2,
       });

--- a/src/components/common/ProfileComponent.tsx
+++ b/src/components/common/ProfileComponent.tsx
@@ -27,7 +27,8 @@ const ProfileComponent = ({
     top: number;
     left: number;
   } | null>(null);
-  const { showBalloon, balloonContent, setShowBalloon } = useBalloonStore(); // 전역 상태 사용
+  const { showBalloon, setShowBalloon } = useBalloonStore(); // 전역 상태 사용
+
   const handleClick = () => {
     if (fileInputRef.current && isEditing) {
       fileInputRef.current.click();
@@ -37,19 +38,22 @@ const ProfileComponent = ({
   useEffect(() => {
     if (teamLogoRef.current && showBalloon) {
       const rect = teamLogoRef.current.getBoundingClientRect();
-      setBalloonPosition({
-        top: rect.top - 30, // 팀 로고 중앙 위쪽에 위치하도록 수정
+      setBalloonPosition({ //중앙 위쪽
+        top: rect.top - 30,
         left: rect.left + rect.width / 2,
       });
     }
+
+    // 말풍선 지속시간 설정
+    const timer = setTimeout(() => {
+      setShowBalloon(false);
+    }, 2000);
+
+    return () => clearTimeout(timer);
   }, [showBalloon]);
 
   const handleLogoHover = () => {
     setShowBalloon(true);
-  };
-
-  const handleLogoLeave = () => {
-    setShowBalloon(false);
   };
 
   return (
@@ -72,12 +76,11 @@ const ProfileComponent = ({
           ref={teamLogoRef}
           onClick={onTeamClick}
           onMouseEnter={handleLogoHover}
-          onMouseLeave={handleLogoLeave}
         >
           <TeamLogoImg src={TeamLogo || defaultStadium} alt="구장 이미지" />
           {showBalloon && (
             <Balloon
-              content={'팬 구단을 설정해요!'}
+              content={"팬 구단을 설정해요!"}
               position={{ top: -30, left: "50%" }}
             />
           )}

--- a/src/components/common/ProfileComponent.tsx
+++ b/src/components/common/ProfileComponent.tsx
@@ -1,8 +1,10 @@
-import { useRef } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import styled from "styled-components";
 import pencilIcon from "../../assets/icons/pencil.svg";
 import defaultProfile from "../../assets/images/default-profile.svg";
 import defaultStadium from "../../assets/images/default-stadium.svg";
+import Balloon from "./Balloon";
+import useBalloonStore from "../../store/ballonStore";
 
 interface ProfileComponentProps {
   profileImage: string | null;
@@ -20,11 +22,34 @@ const ProfileComponent = ({
   isEditing,
 }: ProfileComponentProps) => {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-
+  const teamLogoRef = useRef<HTMLDivElement | null>(null);
+  const [balloonPosition, setBalloonPosition] = useState<{
+    top: number;
+    left: number;
+  } | null>(null);
+  const { showBalloon, balloonContent, setShowBalloon } = useBalloonStore(); // 전역 상태 사용
   const handleClick = () => {
     if (fileInputRef.current && isEditing) {
-      fileInputRef.current.click(); // 파일 선택창 열기 (편집 모드일 때만)
+      fileInputRef.current.click();
     }
+  };
+
+  useEffect(() => {
+    if (teamLogoRef.current && showBalloon) {
+      const rect = teamLogoRef.current.getBoundingClientRect();
+      setBalloonPosition({
+        top: rect.top - 30, // 팀 로고 중앙 위쪽에 위치하도록 수정
+        left: rect.left + rect.width / 2,
+      });
+    }
+  }, [showBalloon]);
+
+  const handleLogoHover = () => {
+    setShowBalloon(true);
+  };
+
+  const handleLogoLeave = () => {
+    setShowBalloon(false);
   };
 
   return (
@@ -43,8 +68,19 @@ const ProfileComponent = ({
           />
         </>
       ) : (
-        <TeamLogoContainer onClick={onTeamClick}>
+        <TeamLogoContainer
+          ref={teamLogoRef}
+          onClick={onTeamClick}
+          onMouseEnter={handleLogoHover}
+          onMouseLeave={handleLogoLeave}
+        >
           <TeamLogoImg src={TeamLogo || defaultStadium} alt="구장 이미지" />
+          {showBalloon && (
+            <Balloon
+              content={'팬 구단을 설정해요!'}
+              position={{ top: -30, left: "50%" }}
+            />
+          )}
         </TeamLogoContainer>
       )}
     </ProfileContainer>

--- a/src/components/myPage/TeamSelector.tsx
+++ b/src/components/myPage/TeamSelector.tsx
@@ -231,4 +231,3 @@ const TextButton = styled(Button)`
     font-size: 0.8rem;
   }
 `;
-ㄴ

--- a/src/components/myPage/TeamSelector.tsx
+++ b/src/components/myPage/TeamSelector.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import useStore from "../../store/PreferTeamStore";
 import { mypage } from "../../apis/mypage";
 import useModalStore from "../../store/modalStore";
+import useBalloonStore from "../../store/ballonStore";
 
 interface TeamSelectorProps {
   teamLogos: Record<string, string>;
@@ -24,6 +25,7 @@ const TeamSelector: React.FC<TeamSelectorProps> = ({
   const { setPreferTeam } = useStore();
   const containerRef = useRef<HTMLDivElement>(null);
   const { openModal, closeModal } = useModalStore();
+  const { setShowBalloon } = useBalloonStore(); // 말풍선 상태 업데이트 함수
 
   // 외부 클릭 시 비활성화
   useEffect(() => {
@@ -45,7 +47,10 @@ const TeamSelector: React.FC<TeamSelectorProps> = ({
 
   const handleButtonClick = useCallback(
     (team: string) => {
-      if (!isEnabled) return;
+      if (!isEnabled) {
+        setShowBalloon(true, `비활성화된 상태입니다. "${team}" 팀 선택 불가`); // 말풍선 표시
+        return;
+      }
       openModal({
         title: "선호 팀 변경",
         content: `"${team}" 팀으로 변경하시겠습니까?`,

--- a/src/components/myPage/TeamSelector.tsx
+++ b/src/components/myPage/TeamSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import useStore from "../../store/PreferTeamStore";
 import { mypage } from "../../apis/mypage";
@@ -25,7 +25,8 @@ const TeamSelector: React.FC<TeamSelectorProps> = ({
   const { setPreferTeam } = useStore();
   const containerRef = useRef<HTMLDivElement>(null);
   const { openModal, closeModal } = useModalStore();
-  const { setShowBalloon } = useBalloonStore(); // 말풍선 상태 업데이트 함수
+  const { setShowBalloon } = useBalloonStore();
+  const [clickCount, setClickCount] = useState(0); // 클릭 횟수 상태 추가
 
   // 외부 클릭 시 비활성화
   useEffect(() => {
@@ -48,7 +49,11 @@ const TeamSelector: React.FC<TeamSelectorProps> = ({
   const handleButtonClick = useCallback(
     (team: string) => {
       if (!isEnabled) {
-        setShowBalloon(true, `비활성화된 상태입니다. "${team}" 팀 선택 불가`); // 말풍선 표시
+        setClickCount((prev) => prev + 1);
+        if (clickCount + 1 >= 2) {
+          setShowBalloon(true);
+          setClickCount(0);
+        }
         return;
       }
       openModal({
@@ -70,7 +75,7 @@ const TeamSelector: React.FC<TeamSelectorProps> = ({
         showCancel: true,
       });
     },
-    [isEnabled, setSelectedTeam, setPreferTeam, openModal]
+    [isEnabled, clickCount, setSelectedTeam, setPreferTeam, openModal]
   );
 
   return (
@@ -226,3 +231,4 @@ const TextButton = styled(Button)`
     font-size: 0.8rem;
   }
 `;
+ㄴ

--- a/src/pages/myPage/MyPageLayout.tsx
+++ b/src/pages/myPage/MyPageLayout.tsx
@@ -8,7 +8,7 @@ import { mypage } from "../../apis/mypage";
 
 const MyPageLayout = () => {
   const { openModal, closeModal } = useModalStore();
-  const { preferTeam, setTeamSelectorActive } = useStore();
+  const { preferTeam, setTeamSelectorActive, isTeamSelectorActive } = useStore();
   const navigate = useNavigate();
 
   const handleTeamClick = () => {
@@ -24,7 +24,7 @@ const MyPageLayout = () => {
         showCancel: true,
       });
     } else {
-      setTeamSelectorActive(true);
+      setTeamSelectorActive(!isTeamSelectorActive);
     }
   };
 
@@ -80,7 +80,6 @@ const PageContainer = styled.div`
 const MenuContainer = styled.div`
   flex: 1;
   min-width: 240px;
-  overflow: hidden; /* 내부 컨텐츠가 넘치지 않도록 */
 `;
 
 const ContentContainer = styled.div`

--- a/src/store/PreferTeamStore.ts
+++ b/src/store/PreferTeamStore.ts
@@ -7,11 +7,11 @@ interface TeamState {
   setPreferTeam: (team: string) => void;
 }
 
-const useStore = create<TeamState>((set) => ({
+const useTeamStore = create<TeamState>((set) => ({
   isTeamSelectorActive: false,
   preferTeam: "",
   setTeamSelectorActive: (active) => set({ isTeamSelectorActive: active }),
   setPreferTeam: (team) => set({ preferTeam: team }),
 }));
 
-export default useStore;
+export default useTeamStore;

--- a/src/store/ballonStore.ts
+++ b/src/store/ballonStore.ts
@@ -1,0 +1,18 @@
+import create from "zustand";
+
+// 상태 타입 정의
+interface BalloonState {
+  showBalloon: boolean;
+  balloonContent: string;
+  setShowBalloon: (show: boolean, content?: string) => void;
+}
+
+// Zustand 스토어 생성
+const useBalloonStore = create<BalloonState>((set) => ({
+  showBalloon: false,
+  balloonContent: "",
+  setShowBalloon: (show, content = "") =>
+    set({ showBalloon: show, balloonContent: content }),
+}));
+
+export default useBalloonStore;

--- a/src/types/myPageType.ts
+++ b/src/types/myPageType.ts
@@ -23,6 +23,7 @@ export interface MyBookMarkResponse {
 }
 //내정보
 export interface MyInfo {
+  [x: string]: string;
   fanTeamName: string;
   nickname: string;
   image: string;


### PR DESCRIPTION
<!--
PR 이름 컨벤션
feat: ~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #92

## ✨ PR 세부 내용
- 내 팀 구단 로고 호버 시 도움말 띄우기
- 팀 구단 선택 여러번 클릭 시 도움말 띄우기
- 도움말(Balloon)의 show 상태 전역관리해서 teamselector, profileComponent에서 둘다 사용할 수 있게 했습니다.

## ⌛ 소요 시간
2h